### PR TITLE
[DEV] ReadTemplate

### DIFF
--- a/xsInterface/functions/readtemplate.py
+++ b/xsInterface/functions/readtemplate.py
@@ -416,6 +416,12 @@ def _CleanDataCopy(dataIn, fmt0):
                         tline =\
                             tline.replace('{}'.format(strsComplete[istrExe]),
                                           fmt.format(*evalexpr))
+                    elif isinstance(evalexpr, str):
+                        # replace execution occurrences without using 
+                        # formatting code
+                        tline =\
+                            tline.replace('{}'.format(strsComplete[istrExe]),
+                                          evalexpr)
                     else:
                         # replace execution occurrences
                         tline =\


### PR DESCRIPTION
Using string input variables can be useful for defining histories in a template file, for example:

"vari"{history="nominalHistory"}
"values"{attr stateParam=stateVal history="varo"{history}}

that way the same template file can be used for multiple history variations. Currently, such use throws an error:

Unknown format code 'd' for object of type 'str'

because the default formatting system was not built for strings (which do not need to be formatted).}