### PR TITLE
Fixed bug with branch names for single branch cases

### DIFF
--- a/xsInterface/functions/readserpent.py
+++ b/xsInterface/functions/readserpent.py
@@ -207,6 +207,12 @@ def _ReadCoefFile(coeFile):
     for brKeys, brData in coe0.items():
         # converet to lower case
         brKeysLower = tuple([i.lower() for i in brKeys])
+
+        if isinstance(brKeys, str):
+            # If only a single branch, brKeys is only a single string, not a list
+            # and so the lowering operation incorrectly returns a list of individual letters
+            brKeysLower = (''.join(brKeysLower),)
+        
         # Loop over all the universes and time points
         for univKey in brData:
             


### PR DESCRIPTION
## The Error

For input files with a single branch variation (i.e. `set branches 1 ...`), the branch keys are improperly parsed, causing an error 
```
"Branch <{}> not provided\nfor univ=<{}>; "
                            "history=<{}>.\nCheck that order of branches card "
                            "correspond to the order provided in the .coe file"
                            .format(branchId, univId, histId))
```

For example
```
set branches 1
tfuel 600 900

set label 1
tfuel tfu600 tfu900

...
```
gives the error:
```
Branch <'t', 'f', 'u', '6', '0', '0'> not provided for univ=<0> history=<his_nom>. 
Check that order of branches card correspond to the order provided in the .coe file.
```

## The Cause
When only a single branch variation is specified in the Serpent input, in the following lines of code
```
coe0 = serpentTools.read(coeFile)
for brKeys, brData in coe0.items():
      ...

```
brKeys is just a _string_, rather than a tuple in the case of multiple branch variations. This causes the lower case method to improperly parse the branch key(s):
```
brKeysLower = tuple([i.lower() for i in brKeys])
```
as shown in the example error message above.
